### PR TITLE
added documentation when to use icinga_business_process_force_basic_auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ If you get this type of error it probably means that a node or service was speci
 ```bash
 "Status code was 200 and not [302]: OK (unknown bytes)"
 ```
+
+There are some cases where you need to set the variable `icinga_business_process_force_basic_auth` to `true`, otherwise you will get the following error from every play where the Ansible uri module is used:
+
+```bash
+AbstractDigestAuthHandler does not support the following scheme: ''Negotiate''
+```
 ## License
 
 GPLv3

--- a/roles/ansible_icinga_business_process/README.md
+++ b/roles/ansible_icinga_business_process/README.md
@@ -71,7 +71,7 @@ Including an example of how to use your role (for instance, with variables passe
     icinga_business_process_user: username
     icinga_business_process_password: loginpassword
     icinga_business_process_url: https://icinga.example.com
-    icinga_business_process_force_basic_auth: True
+    icinga_business_process_force_basic_auth: true
     icinga_business_processes:
       - title: ansible-test
         description: Test Business process for Ansible Role


### PR DESCRIPTION
There was some documentation missing when it makes sense to set the variable icinga_business_process_force_basic_auth to true.